### PR TITLE
Add support for modern REDCap hooks and basic logging

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2015 University of Florida
+Copyright 2017 University of Florida
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ multiple implementations per hook. Each hook-function in that file looks for
 actual hooks in other PHP files with the same name as the hook.
 
 For example, if you wanted to add functionality when displaying a data entry
-form, the hook is called "redcap_data_entry_form". So, you would create a
-"redcap_data_entry_form.php" file with your hook-function in it.
+form, the hook is called `redcap_data_entry_form`. So, you would create a
+`redcap_data_entry_form.php` file with your hook-function in it.
 
 
 ## Writing Hook-functions
@@ -87,6 +87,20 @@ Since `redcap_custom_verify_username` has a non-void return type it has to be
 implemented only if needed and directly in `redcap_hooks.php` as per the REDCap
 documentation.
 
+## Logging
+
+To activate logging on a specific hook_function, add a `TRUE` as the third
+parameter of the call to `redcap_hooks_find` within that hook function.  E.g., turn
+
+    $hook_files = redcap_hooks_find('redcap_data_entry_form_top', $project_id);
+
+into
+
+    $hook_files = redcap_hooks_find('redcap_data_entry_form_top', $project_id, TRUE);
+
+Hook logging output will be written to `/tmp/hook_events.log` This can be changed by editing
+the `redcap_hooks_find` function.
+
 
 ## Contributors
 
@@ -99,5 +113,5 @@ custom REDCap Hooks.
 
 ## License
 
-Copyright 2015, University of Florida; licensed under the Apache License,
+Copyright 2017, University of Florida; licensed under the Apache License,
 Version 2.0. See the [LICENSE](LICENSE) file for the full text.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For example:
   - `pid12/redcap_data_entry_form/9-more-stuff.php`
 
 
-## Summary of File Naming Convetion
+## Summary of File Naming Convention
 
 Hooks are searched for in four places, all relative to the folder in which
 `redcap_hooks.php` resides:

--- a/redcap_hooks.php
+++ b/redcap_hooks.php
@@ -46,6 +46,20 @@
  */
 
 /**
+ * Finds and runs `redcap_add_edit_records_page` hooks
+ * @see REDCap Hooks documentation
+ */
+function redcap_add_edit_records_page($project_id, $instrument, $event_id)
+{
+	$hook_files = redcap_hooks_find('redcap_add_edit_records_page');
+
+	foreach ($hook_files as $filename) {
+		$hook = include $filename;
+		$hook($project_id, $instrument, $event_id);
+	}
+}
+
+/**
  * Finds and runs `redcap_control_center` hooks
  * @see REDCap Hooks documentation
  */
@@ -74,6 +88,63 @@ function redcap_data_entry_form($project_id, $record, $instrument, $event_id,
 	foreach ($hook_files as $filename) {
 		$hook = include $filename;
 		$hook($project_id, $record, $instrument, $event_id, $group_id);
+	}
+}
+
+/**
+ * Finds and runs `redcap_data_entry_form_top` hooks
+ * @see REDCap Hooks documentation
+ */
+function redcap_data_entry_form_top($project_id, $record, $instrument, $event_id,
+	$group_id)
+{
+	$hook_files = redcap_hooks_find('redcap_data_entry_form_top', $project_id);
+
+	foreach ($hook_files as $filename) {
+		$hook = include $filename;
+		$hook($project_id, $record, $instrument, $event_id, $group_id);
+	}
+}
+
+/**
+ * Finds and runs `redcap_every_page_before_render` hooks
+ * @see REDCap Hooks documentation
+ */
+function redcap_every_page_before_render($project_id)
+{
+	$hook_files = redcap_hooks_find('redcap_every_page_before_render');
+
+	foreach ($hook_files as $filename) {
+		$hook = include $filename;
+		$hook($project_id);
+	}
+}
+
+/**
+ * Finds and runs `redcap_every_page_top` hooks
+ * @see REDCap Hooks documentation
+ */
+function redcap_every_page_top($project_id)
+{
+	$hook_files = redcap_hooks_find('redcap_every_page_top');
+
+	foreach ($hook_files as $filename) {
+		$hook = include $filename;
+		$hook($project_id);
+	}
+}
+
+/**
+ * Finds and runs `redcap_project_home_page` hooks
+ * @see REDCap Hooks documentation
+ */
+function redcap_project_home_page($project_id)
+{
+	$hook_files = redcap_hooks_find('redcap_project_home_page');
+
+	foreach ($hook_files as $filename) {
+		$hook = include $filename;
+		$hook($project_id);
 	}
 }
 
@@ -117,6 +188,22 @@ function redcap_survey_page($project_id, $record, $instrument, $event_id,
 	$group_id, $survey_hash, $response_id)
 {
 	$hook_files = redcap_hooks_find('redcap_survey_page', $project_id);
+
+	foreach ($hook_files as $filename) {
+		$hook = include $filename;
+		$hook($project_id, $record, $instrument, $event_id, $group_id,
+			$survey_hash, $response_id);
+	}
+}
+
+/**
+ * Finds and runs `redcap_survey_page_top` hooks
+ * @see REDCap Hooks documentation
+ */
+function redcap_survey_page_top($project_id, $record, $instrument, $event_id,
+	$group_id, $survey_hash, $response_id)
+{
+	$hook_files = redcap_hooks_find('redcap_survey_page_top', $project_id);
 
 	foreach ($hook_files as $filename) {
 		$hook = include $filename;

--- a/redcap_hooks.php
+++ b/redcap_hooks.php
@@ -51,7 +51,7 @@
  */
 function redcap_add_edit_records_page($project_id, $instrument, $event_id)
 {
-	$hook_files = redcap_hooks_find('redcap_add_edit_records_page');
+	$hook_files = redcap_hooks_find('redcap_add_edit_records_page', $project_id);
 
 	foreach ($hook_files as $filename) {
 		$hook = include $filename;
@@ -112,7 +112,7 @@ function redcap_data_entry_form_top($project_id, $record, $instrument, $event_id
  */
 function redcap_every_page_before_render($project_id)
 {
-	$hook_files = redcap_hooks_find('redcap_every_page_before_render');
+	$hook_files = redcap_hooks_find('redcap_every_page_before_render', $project_id);
 
 	foreach ($hook_files as $filename) {
 		$hook = include $filename;
@@ -126,7 +126,7 @@ function redcap_every_page_before_render($project_id)
  */
 function redcap_every_page_top($project_id)
 {
-	$hook_files = redcap_hooks_find('redcap_every_page_top');
+	$hook_files = redcap_hooks_find('redcap_every_page_top', $project_id);
 
 	foreach ($hook_files as $filename) {
 		$hook = include $filename;
@@ -140,7 +140,7 @@ function redcap_every_page_top($project_id)
  */
 function redcap_project_home_page($project_id)
 {
-	$hook_files = redcap_hooks_find('redcap_project_home_page');
+	$hook_files = redcap_hooks_find('redcap_project_home_page', $project_id);
 
 	foreach ($hook_files as $filename) {
 		$hook = include $filename;

--- a/redcap_hooks.php
+++ b/redcap_hooks.php
@@ -142,12 +142,12 @@ function redcap_user_rights($project_id)
 /**
  * Returns filenames matching our file-based, naming convention
  */
-function redcap_hooks_find($hook_name, $project_id = '')
+function redcap_hooks_find($hook_function, $project_id = '')
 {
 	return array_merge(
-		glob(__DIR__ . "/$hook_name.php"),
-		glob(__DIR__ . "/$hook_name/*.php"),
-		glob(__DIR__ . "/pid$project_id/$hook_name.php"),
-		glob(__DIR__ . "/pid$project_id/$hook_name/*.php")
+		glob(__DIR__ . "/$hook_function.php"),
+		glob(__DIR__ . "/$hook_function/*.php"),
+		glob(__DIR__ . "/pid$project_id/$hook_function.php"),
+		glob(__DIR__ . "/pid$project_id/$hook_function/*.php")
 	);
 }

--- a/redcap_hooks.php
+++ b/redcap_hooks.php
@@ -27,7 +27,7 @@
  * "pid{$project_id}", where $project_id is the project's REDCap ID. So, for
  * project 12, create "pid12/redcap_data_entry_form.php".
  *
- * Furthermore, if you have more than one hooks, you can create a folder named
+ * Furthermore, if you have more than one hook, you can create a folder named
  * after the hook, and all PHP files under that folder will be detected. For
  * example:
  *

--- a/redcap_hooks.php
+++ b/redcap_hooks.php
@@ -1,7 +1,7 @@
 <?php
 ###############################################################################
-# Copyright 2015 Univeristy of Florida. All rights reserved.
-# This file is part of the redcap-extras project.
+# Copyright 2017 University of Florida. All rights reserved.
+# This file was originally part of the redcap-extras project.
 # Use of this source code is governed by the license found in the LICENSE file.
 ###############################################################################
 
@@ -9,7 +9,7 @@
  * REDCap Hooks
  *
  *   Requires PHP >= 5.3.0
- *   Tested with REDCap 6.0.5 LTS.
+ *   Tested with REDCap 6.18.1, 7.2.2.
  *
  * This file enables the file-based management of REDCap Hooks. REDCap supports
  * only one hooks file, specified under Control Center > REDCap Hooks. This
@@ -37,14 +37,24 @@
  *   pid12/redcap_data_entry_form/9-more-stuff.php
  *
  * To activate logging on a specific hook_function, add a TRUE as the third
- * parameter of the call of redcap_hooks_find in within that hook_function
+ * parameter of the call to redcap_hooks_find within that hook_function.  E.g., turn
+ *
+ *      $hook_files = redcap_hooks_find('redcap_data_entry_form_top', $project_id);
+ *
+ * into
+ *
+ *      $hook_files = redcap_hooks_find('redcap_data_entry_form_top', $project_id, TRUE);
+ *
+ * Hook logging output will be written to `/tmp/hook_events.log` This can be changed by editing
+ * the redcap_hooks_find function.  TODO: Make logging activation and the log file configurable.
+ *
  *
  * Caveat: Since `redcap_custom_verify_username` has a non-void return type, it
  * is not supported. You'll have to implement the function in this file per the
  * REDCap documentation.
  *
  * @author Taeber Rapczak <taeber@ufl.edu>
- * @copyright Copyright 2015, University of Florida
+ * @copyright Copyright 2017, University of Florida
  * @license See above
  */
 


### PR DESCRIPTION
These PR will add support for all of the modern REDCap Hooks up through version 7.2.2. It also adds a basic logging function that allows the request and hooks found to be logged on a per-hook_function basis. 

Activation of the logging is _not_ externally configurable, but it is a first step towards that goal. The logging proved useful in testing to verify the hook framework was working and that the desired hooks had been activated.